### PR TITLE
SVGコピー機能修正

### DIFF
--- a/app/views/pasteup/_pdf.html.haml
+++ b/app/views/pasteup/_pdf.html.haml
@@ -70,7 +70,7 @@
             font-size: 13px;
             fill:#ffff00;
             }
-            .label-inkfactory{
+            .label-blackfactory{
             font-family: 'HiraginoSans-W6-83pv-RKSJ-H';
             font-size: 13px;
             fill:#000000;
@@ -130,7 +130,7 @@
             }
 
             .delivery-date{
-              fill:red;
+              fill:#ff0000;
               font-family: 'HiraginoSans-W7-83pv-RKSJ-H';
               font-size: 30px;
             }
@@ -143,12 +143,21 @@
               font-family:'KozGoPr6N-Regular-83pv-RKSJ-H';
               font-size: 12px;
             }
-
-            .absoluteness{
-              font-family:'KozGoPr6N-Regular-83pv-RKSJ-H';
-              font-size: 24px;
+            .order-type{
+              fill:#00A0E9;
+              font-family: 'HiraginoSans-W8-83pv-RKSJ-H';
+              font-size: 20px;
             }
-
+            .absoluteness{
+              font-family: 'HiraginoSans-W6-83pv-RKSJ-H';
+              font-size: 30px;
+            }
+            .must-arrive{
+              fill:#ff0000;
+            }
+            .around-arrive{
+              fill:#000000;
+            }
             .id{
               font-family: 'HiraginoSans-W7-83pv-RKSJ-H';
               font-size: 15px;
@@ -196,7 +205,6 @@
               font-size: 8px;
               line-height: 12px;
             }
-
             .estimation{
               font-family:'KozGoPr6N-Regular-83pv-RKSJ-H';
               font-size: 10px;
@@ -212,6 +220,16 @@
               }
             .note-checkbox{
               font-size: 30px;
+              font-family: 'HiraginoSans-W7-83pv-RKSJ-H';
+              fill:#00ffff;
+            }
+            .including{
+              font-size: 21px;
+              font-family: 'HiraginoSans-W7-83pv-RKSJ-H';
+              fill:#ff0000;
+            }
+            .including-checkbox{
+              font-size: 21px;
               font-family: 'HiraginoSans-W7-83pv-RKSJ-H';
               fill:#00ffff;
             }
@@ -295,8 +313,8 @@
           -# %path#path36.st10{:d => "m 7.09,245 h 581.1"}
           -# %path#path38.st9{:d => "m 311.79,174.87 v 22.1"}
         -#%g#text-contents
-        - if Technique.find_by(technique_name: @technique).id == 4
-          %text.label-inkfactory{:x => "10", :y => "26.555"}
+        - if Technique.find_by(technique_name: @technique).id == 4 || Technique.find_by(technique_name: @technique).id == 3
+          %text.label-blackfactory{:x => "10", :y => "26.555"}
             - if Factory.find_by(id: @order_detail.factory_id).id == 4
               戸田１
             - if Factory.find_by(id: @order_detail.factory_id).id == 7
@@ -336,7 +354,7 @@
 
         %text.body-order{:x => "139.662", :y => "23.104"}
         %text.body-order{:x => "221.995", :y => "23.104"}
-        %text.body-ordr-box{:x => "152.28999", :y => "36.463001"}
+        %text.body-order-box{:x => "152.28999", :y => "36.463001"}
         -#%text.payment{:x => "389.04599", :y => "22.348"} 入金
         %text.payment-done{:x => "409.94901", :y => "35.707001"} 済
         %text.customer-name{:x => "13.023", :y => "80.526001"} #{@customer.customer_name}
@@ -373,6 +391,12 @@
                 #{l(@order.try(:desired_delivery_date), format: :middle, default: '')}までに
               - elsif @order.desired_delivery_type_id == 3 || @order.desired_delivery_type_id == 4
                 #{l(@order.try(:desired_delivery_date), format: :middle, default: '')}前後
+        - if @order.order_type_id == 3
+          %text.order-type{:x => "170", :y => "130"}
+            不備クレーム
+        - elsif @order.order_type_id >= 4 && @order.order_type_id <= 8
+          %text.order-type{:x => "210", :y => "130"}
+            後納
         %g#special-mark{:x => "330.86", :y => "148.16"}
           - if @order.customer.customer_type_id == 2
             %g#dangerous-mark{:transform => "translate(290 90)"}
@@ -477,6 +501,12 @@
 
         -# %text.absoluteness{:x => "455", :y => "131.375"} 絶対 / 通常
         -# %ellipse{:cx => "480.97", :cy => "119.82", :fill => "none", :rx => "29.59", :ry => "28.34", :stroke => "#e60012", "stroke-miterlimit" => "10", "stroke-width" => "3"}
+        %text.absoluteness{:x => "480", :y => "135"}
+          - if @order.desired_delivery_date.present?
+            - if @order.desired_delivery_type_id == 1 || @order.desired_delivery_type_id == 2
+              %tspan.must-arrive 絶対
+            - elsif @order.desired_delivery_type_id == 3 || @order.desired_delivery_type_id == 4
+              %tspan.around-arrive 前後
         -# %text.id{:x => "19.663", :y => "170.533"} ID
         %text.id-box{:x => "63.007999", :y => "168.01801"} #{@order.uid}
         -# %text.picking{:x => "65.120003", :y => "189.54601"} ピッキング:
@@ -547,3 +577,125 @@
               %tspan.note-box 制作完了後に写真送信
               %tspan.note-checkbox □
             -#{OrderOption.find(order_detail_option.order_option_id).order_option_name}
+        -#同梱処理
+        -# %text.including{:x => "500", :y => "811"}
+        - OrderDetail.where(order_id: @order.id).where.not(id: params[:詳細番号]).each do |order_detail|
+          - OrderTechniqueDetail.where(order_detail_id: order_detail.id).each do |order_technique_detail|
+            -#この指示書がシルクA以外の時に、合体以外の他の加工に同じ工場のシルクAがある場合、シルク同梱
+            - if Technique.find_by(technique_name: @technique).id != 1
+              - if Technique.find(order_technique_detail.technique_id).id == 1
+                - if Factory.find_by(id: @order_detail.factory_id).id == Technique.find(order_detail.factory_id).id
+                  %text.including.silk{:x => "450", :y => "828"}
+                    %tspan.including シルク同梱
+                    %tspan.including-checkbox □
+            -#この指示書がシルクB以外の時に、合体以外の他の加工に同じ工場のシルクBがある場合、Sticker同梱
+            - if Technique.find_by(technique_name: @technique).id != 2
+              - if Technique.find(order_technique_detail.technique_id).id == 2
+                - if Factory.find_by(id: @order_detail.factory_id).id == Technique.find(order_detail.factory_id).id
+                  %text.including.silk{:x => "300", :y => "808"}
+                    %tspan.including Sticker同梱
+                    %tspan.including-checkbox □
+            -#この指示書がインクジェット以外の時に、合体以外の他の加工に同じ工場のインクジェットがある場合、インク同梱
+            - if Technique.find(order_technique_detail.technique_id).id == 4
+              - if Technique.find_by(technique_name: @technique).id != 4
+                - if Factory.find_by(id: @order_detail.factory_id).id == Technique.find(order_detail.factory_id).id
+                  %text.including.silk{:x => "450", :y => "808"}
+                    %tspan.including インク同梱
+                    %tspan.including-checkbox □
+            -#この指示書が刺繍以外の時に、合体以外の他の加工に同じ工場の刺繍がある場合、刺繍同梱
+            - if Technique.find(order_technique_detail.technique_id).id == 5
+              - if Technique.find_by(technique_name: @technique).id != 5
+                - if Factory.find_by(id: @order_detail.factory_id).id == Technique.find(order_detail.factory_id).id
+                  %text.including.silk{:x => "470", :y => "788"}
+                    %tspan.including 刺繍同梱
+                    %tspan.including-checkbox □
+            -#この指示書がUV以外の時に、合体以外の他の加工に同じ工場のUVがある場合、UV同梱
+            - if Technique.find(order_technique_detail.technique_id).id == 7
+              - if Technique.find_by(technique_name: @technique).id != 7
+                - if Factory.find_by(id: @order_detail.factory_id).id == Technique.find(order_detail.factory_id).id
+                  %text.including.silk{:x => "450", :y => "828"}
+                    %tspan.including UV同梱
+                    %tspan.including-checkbox □
+            -#この指示書がシルクD以外の時に、合体以外の他の加工に同じ工場のシルクDがある場合、PAD同梱
+            - if Technique.find(order_technique_detail.technique_id).id == 8
+              - if Technique.find_by(technique_name: @technique).id != 8
+                - if Factory.find_by(id: @order_detail.factory_id).id == Technique.find(order_detail.factory_id).id
+                  %text.including.silk{:x => "450", :y => "828"}
+                    %tspan.including PAD同梱
+                    %tspan.including-checkbox □
+            -#この指示書が加工なし以外の時に、合体以外の他の加工に同じ工場の加工なしがある場合、加工なし同梱
+            - if Technique.find(order_technique_detail.technique_id).id == 9
+              - if Technique.find_by(technique_name: @technique).id != 9
+                - if Factory.find_by(id: @order_detail.factory_id).id == Technique.find(order_detail.factory_id).id
+                  %text.including.silk{:x => "300", :y => "828"}
+                    %tspan.including 加工なし同梱
+                    %tspan.including-checkbox □
+
+              -#シルク指示書でインク同梱
+              -#シルク指示書で刺繍同梱
+              -#シルク指示書でNTタグ同梱
+              -#シルク指示書でsticker同梱
+              -#シルク指示書でPAD同梱
+              -#シルク指示書でUV同梱
+              -#シルク指示書でシルク+刺繍同梱
+              -#シルク指示書でPAD+UV同梱
+              -#シルク指示書で加工無し同梱
+
+              -#インクジェット指示書でシルク同梱
+              -#インクジェット指示書で刺繍同梱
+              -#インクジェット指示書でNTタグ同梱
+              -#インクジェット指示書でsticker同梱
+              -#インクジェット指示書でPAD同梱
+              -#インクジェット指示書でUV同梱
+              -#インクジェット指示書でシルク+刺繍同梱
+              -#インクジェット指示書でPAD+UV同梱
+              -#インクジェット指示書で加工無し同梱
+
+              -#刺繍指示書でシルク同梱
+              -#刺繍指示書でインクジェット同梱
+              -#刺繍指示書でNTタグ同梱
+              -#刺繍指示書でsticker同梱
+              -#刺繍指示書でPAD同梱
+              -#刺繍指示書でUV同梱
+              -#刺繍指示書でシルク+刺繍同梱
+              -#刺繍指示書でPAD+UV同梱
+              -#刺繍指示書で加工無し同梱
+
+              -#UV指示書でシルク同梱
+              -#UV指示書でインクジェット同梱
+              -#UV指示書でNTタグ同梱
+              -#UV指示書でsticker同梱
+              -#UV指示書でPAD同梱
+              -#UV指示書で刺繍同梱
+              -#UV指示書でシルク+刺繍同梱
+              -#UV指示書でPAD+UV同梱
+              -#UV指示書でシルク+インク+刺繍同梱
+              -#UV指示書で刺繍+インク同梱
+              -#UV指示書でシルク+インク同梱
+              -#UV指示書で加工無し同梱
+
+              -#PAD指示書でシルク同梱
+              -#PAD指示書でインクジェット同梱
+              -#PAD指示書でNTタグ同梱
+              -#PAD指示書でsticker同梱
+              -#PAD指示書でUV同梱
+              -#PAD指示書で刺繍同梱
+              -#PAD指示書でシルク+刺繍同梱
+              -#PAD指示書でPAD+UV同梱
+              -#PAD指示書でシルク+インク+刺繍同梱
+              -#PAD指示書でインク+刺繍同梱
+              -#PAD指示書でシルク+インク同梱
+              -#PAD指示書で加工無し同梱
+
+              -#NTタグ指示書でシルク同梱
+              -#NTタグ指示書でインクジェット同梱
+              -#NTタグ指示書でNTタグ同梱
+              -#NTタグ指示書でsticker同梱
+              -#NTタグ指示書でUV同梱
+              -#NTタグ指示書で刺繍同梱
+              -#NTタグ指示書でシルク+刺繍同梱
+              -#NTタグ指示書でPAD+UV同梱
+              -#NTタグ指示書でシルク+インク+刺繍同梱
+              -#NTタグ指示書でインク+刺繍同梱
+              -#NTタグ指示書でシルク+インク同梱
+              -#NTタグ指示書で加工無し同梱


### PR DESCRIPTION
 - 不備・クレーム案件の場合不備クレームの表示
 - 後納の場合後納の表示
 - 絶対/通常の欄を　までにと必着は絶対の文字を表示して前後は前後と表示にする
 - もし同じ注文の中に同じ工場の別の加工の同梱があったら備考欄右に表示させる
 - NTタグの工場名も黒にする